### PR TITLE
A simple TAXII client fetching hailataxii samples and save the STIX XML.

### DIFF
--- a/tests/test_taxii.py
+++ b/tests/test_taxii.py
@@ -1,0 +1,19 @@
+from cabby import create_client
+
+client = create_client(
+    'hailataxii.com',
+    use_https=False,
+    discovery_path='/taxii-discovery-service')
+
+services = client.discover_services()
+for service in services:
+    print('Service type={s.type}, address={s.address}'.format(s=service))
+
+collections = client.get_collections('http://hailataxii.com/taxii-data')
+for collection in collections:
+    print (collection.name)
+    f = open(collection.name+'.xml','wb')
+    content_blocks = client.poll(collection_name=collection.name)
+    for block in content_blocks:
+        f.write(block.content)
+    f.close()


### PR DESCRIPTION
A simple TAXII client fetching hailataxii samples and save the STIX XML.

Wanted to try to the converter with sample STIX XML files. I added a simple script (using the TAXII client cabby) that fetch all collections and save them as XML files.

I tried to import them but it seems that the current import script cannot handle STIX XML files. Is this correct? 

