### PR TITLE
chg: Included SSL, backwards compatability, v0.2.2

### DIFF
--- a/misp.login.example
+++ b/misp.login.example
@@ -1,3 +1,4 @@
 MISP:
     URL: https://misp.example.com
     KEY: DEADBEEF123123213
+    SSL: True/False/PathtoKey

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/misp_stix_converter/stix-to-misp.py
+++ b/misp_stix_converter/stix-to-misp.py
@@ -9,6 +9,7 @@
 
 import argparse
 import pyaml
+import time
 import sys
 import os
 
@@ -34,9 +35,15 @@ except FileNotFoundError:
     print("Could not find config file {}".format(configfile))
     sys.exit(1)
 
+# Backwards compatability, if users haven't updated config
+if "SSL" not in CONFIG["MISP"]:
+    print("Please update your config file using the misp.login.example to include SSL")
+    time.sleep(1)
+    CONFIG["MISP"]["SSL"] = False
+
 # This is just a file conversion
 # Relatively quick and easy
-MISP = misp.MISP(CONFIG["MISP"]["URL"], CONFIG["MISP"]["KEY"])
+MISP = misp.MISP(CONFIG["MISP"]["URL"], CONFIG["MISP"]["KEY"], CONFIG["MISP"]["SSL"])
 
 # Load the package
 pkg = open_stix(args.file)


### PR DESCRIPTION
Updated to allow for SSL specification, included backwards compatibility check for those who don't update misp.login file