### PR TITLE
Fixed "AttributeError: 'RelatedObjects' object has no attribute 'hostname'"

### DIFF
--- a/misp_stix_converter/converters/buildMISPAttribute.py
+++ b/misp_stix_converter/converters/buildMISPAttribute.py
@@ -61,10 +61,7 @@ def parseRelated(obj, mispEvent, pkg):
             buildHostnameAttribute(i.properties, mispEvent, pkg)
 
         elif type_ == socket_address_object.SocketAddress:
-            if obj.ip_address:
-                buildAddressAttribute(obj.ip_address, mispEvent, pkg, True)
-        if obj.hostname:
-            buildHostnameAttribute(obj.hostname, mispEvent, pkg, True)
+            buildAddressAttribute(i.properties, mispEvent, pkg, True)
 
         elif type_ == uri_object.URI:
             buildURIAttribute(i.properties, mispEvent, pkg)


### PR DESCRIPTION
Fixed the "AttributeError: 'RelatedObjects' object has no attribute 'hostname'" error.

Now related object seems to work again.
Hope this help.