### PR TITLE
Fix for "buildFileAttribute" - Hashes has no len()

### DIFF
--- a/misp_stix_converter/converters/buildMISPAttribute.py
+++ b/misp_stix_converter/converters/buildMISPAttribute.py
@@ -108,20 +108,20 @@ def buildFileAttribute(obj, mispEvent, pkg, importRelated=False):
     if obj.md5:
         # We actually have to check the length
         # An actual report had supposed md5s of length 31. Silly.
-        if len(obj.md5) == 32:
+        if len(str(obj.md5)) == 32:
             mispEvent.add_attribute('md5', ast_eval(str(obj.md5)), comment=pkg.title or None)
 
     if obj.sha1:
-        if len(obj.sha1) == 40:
+        if len(str(obj.sha1)) == 40:
             mispEvent.add_attribute('sha1', ast_eval(str(obj.sha1)), comment=pkg.title or None)
 
     if obj.sha256:
-        if len(obj.sha256) == 64:
+        if len(str(obj.sha256)) == 64:
             mispEvent.add_attribute('sha256', ast_eval(str(obj.sha256)), comment=pkg.title or None)
 
     # Added support for SHA512 (DB)
     if obj.sha512:
-        if len(obj.sha512) == 128:
+        if len(str(obj.sha512)) == 128:
             mispEvent.add_attribute('sha512', ast_eval(str(obj.sha512)), comment=pkg.title or None)
 
     if importRelated and pkg.object_.related_objects:


### PR DESCRIPTION
Using the latest OVA image, hashes import from stix file return the following error

```
object of type 'HexBinary' has no len()
object of type 'HexBinary' has no len()
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/misp_stix_converter/converters/buildMISPAttribute.py", line 313, in buildAttribute
    buildFileAttribute(obj, mispEvent, pkg, True)
  File "/usr/local/lib/python3.5/dist-packages/misp_stix_converter/converters/buildMISPAttribute.py", line 111, in buildFileAttribute
    if len(obj.md5) == 32:
TypeError: object of type 'HexBinary' has no len()
```

Should be fixed.