### PR TITLE
Fix for "AttributeError: can't set attribute"

### DIFF
--- a/misp_stix_converter/converters/buildMISPAttribute.py
+++ b/misp_stix_converter/converters/buildMISPAttribute.py
@@ -262,15 +262,16 @@ def buildEvent(pkg, **kwargs):
             log.exception(ex)
     # Now make sure we only have unique items
     log.debug("Making sure we only have Unique attributes...")
-    uniqueAttributes = []
+    
     uniqueAttribValues = []
 
-    for attrib in event.attributes:
+    for attrindex, attrib in enumerate(event.attributes):
         if attrib.value not in uniqueAttribValues:
-            uniqueAttributes.append(attrib)
             uniqueAttribValues.append(attrib.value)
+        else:
+            log.debug("Removed duplicated attribute in package: "+attrib.value)
+            event.attributes.pop(attrindex)
 
-    event.attributes = uniqueAttributes
     log.debug("Finished parsing attributes.")
     return event
 


### PR DESCRIPTION
In the latest VM version availables (ccb3118940f9fcdf356126bed4370f3e7b5900a2) STIX import does not work.
Maybe caused by a change in another library (from pymisp import mispevent).

The error reported
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/misp_modules/__init__.py", line 197, in post
    response = yield tornado.gen.with_timeout(timeout, self.run_request(jsonpayload))
  File "/usr/local/lib/python3.6/dist-packages/tornado/gen.py", line 1055, in run
    value = future.result()
  File "/usr/local/lib/python3.6/dist-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/dist-packages/misp_modules/__init__.py", line 185, in run_request
    response = mhandlers[x['module']].handler(q=jsonpayload)
  File "modules/import_mod/stiximport.py", line 35, in handler
    pkg = stix.load_stix(package)
  File "/usr/local/lib/python3.6/dist-packages/pymisp/tools/stix.py", line 18, in load_stix
    threat_level_id=threat_level_id, analysis=analysis)
  File "/usr/local/lib/python3.6/dist-packages/misp_stix_converter/converters/buildMISPAttribute.py", line 273, in buildEvent
    event.attributes = uniqueAttributes
AttributeError: can't set attribute
```