### PR TITLE
STIX file does not lost Marking infos

### DIFF
--- a/misp_stix_converter/converters/convert.py
+++ b/misp_stix_converter/converters/convert.py
@@ -121,9 +121,12 @@ def load_stix(stix):
             ns_map = stixXml.nsmap
 
             # Remove any "marking" sections because the US-Cert is evil
-            log.debug("Removing Marking elements...")
-            for element in stixXml.findall(".//{http://data-marking.mitre.org/Marking-1}Marking"):
-                element.getparent().remove(element)
+            #log.debug("Removing Marking elements...")
+            #for element in stixXml.findall(".//{http://data-marking.mitre.org/Marking-1}Marking"):
+            #    element.getparent().remove(element)
+            # Davide Baglieri: removing Marking elements result just in a loss of data.
+            # No problem or bug detected commenting the lines above.
+            # Tested for months in a production environment
 
             log.debug("Writing cleaned XML to Tempfile")
             f = SpooledTemporaryFile(max_size=10 * 1024)


### PR DESCRIPTION
Removing Marking elements result just in a loss of data.
No problem or bug detected commenting the lines above. 

Tested for months in a production environment using this [MISP TAXII HOOK](https://github.com/davidonzo/MISP-Taxii-Server/blob/master/misp_taxii_hooks/hooks.py).