### PR TITLE
Extract description from stix_header

### DIFF
--- a/misp_stix_converter/converters/buildMISPAttribute.py
+++ b/misp_stix_converter/converters/buildMISPAttribute.py
@@ -257,6 +257,10 @@ def buildEvent(pkg, **kwargs):
             title = "STIX Import"
         else:
             title = pkg.stix_header.title
+        if hasattr(pkg.stix_header, "description"):
+            log.debug("Found description %s", pkg.stix_header.description.value)
+            event.add_attribute("comment", pkg.stix_header.description.value)
+
     log.info("Using title %s", title)
 
     log.debug("Seting up MISPEvent...")
@@ -265,10 +269,6 @@ def buildEvent(pkg, **kwargs):
     event.threat_level_id = kwargs.get("threat_level_id", 3)
     event.analysis = kwargs.get("analysis", 0)
     event.info = title
-
-    if hasattr(pkg, "description"):
-        log.debug("Found description %s", pkg.description)
-        event.add_attribute("comment", pkg.description)
 
     log.debug("Beginning to Lint_roll...")
     ids = []


### PR DESCRIPTION
Hello all,

Tiny PR for extracting description field from a STIX file into a MISP comment.

Don't hesitate to contact me if you need some help and if you have some question.

devnull-


#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch (tested and validated)