### PR TITLE
New features: Add attribute tags from indicator metadata and support parsing threatconnect metrics/tags

### DIFF
--- a/misp_stix_converter/converters/buildMISPAttribute.py
+++ b/misp_stix_converter/converters/buildMISPAttribute.py
@@ -20,6 +20,13 @@ from cybox.objects import x509_certificate_object, win_executable_file_object, w
 
 # Just a little containment file for STIX -> MISP conversion
 ipre = re.compile("([0-9]{1,3}.){3}[0-9]{1,3}")
+
+# Precompilie regex patterns for threatconnect
+src_pattern = r"src:\s+([^\|]+)"
+threatassess_pattern = r"threatassess:\s+([^\|]+)"
+falsepositives_pattern = r"falsepositives:\s+([^\|]+)"
+owner_pattern = r"owner:\s+([^\|]+)"
+
 log = logging.getLogger("__main__")
 
 
@@ -92,109 +99,123 @@ def buildFileAttribute(obj, mispEvent, pkg, importRelated=False):
     All you can get by a File object in a single method
     TODO: all possible attributes are not yet parsed
     """
-
+    attribute = None
     if obj.file_name:
-        mispEvent.add_attribute('filename', ast_eval(str(obj.file_name)), comment=pkg.title or None)
+        attribute = mispEvent.add_attribute('filename', ast_eval(
+            str(obj.file_name)), comment=pkg.title or None)
 
     # Added support to file_extension
     # No MISP object available for file extension
     # I propose to use pattern-in-file. Suggestions are welcome! (DB)
     if obj.file_extension:
-        mispEvent.add_attribute('pattern-in-file', ast_eval(str(obj.file_extension)), comment=pkg.title or None)
+        attribute = mispEvent.add_attribute(
+            'pattern-in-file', ast_eval(str(obj.file_extension)), comment=pkg.title or None)
 
     if obj.size_in_bytes:
-        mispEvent.add_attribute('size-in-bytes', ast_eval(str(obj.size_in_bytes)), comment=pkg.title or None)
+        attribute = mispEvent.add_attribute(
+            'size-in-bytes', ast_eval(str(obj.size_in_bytes)), comment=pkg.title or None)
 
     if obj.md5:
         # We actually have to check the length
         # An actual report had supposed md5s of length 31. Silly.
         if len(str(obj.md5)) == 32:
-            mispEvent.add_attribute('md5', ast_eval(str(obj.md5)), comment=pkg.title or None)
+            attribute = mispEvent.add_attribute(
+                'md5', ast_eval(str(obj.md5)), comment=pkg.title or None)
 
     if obj.sha1:
         if len(str(obj.sha1)) == 40:
-            mispEvent.add_attribute('sha1', ast_eval(str(obj.sha1)), comment=pkg.title or None)
+            attribute = mispEvent.add_attribute(
+                'sha1', ast_eval(str(obj.sha1)), comment=pkg.title or None)
 
     if obj.sha256:
         if len(str(obj.sha256)) == 64:
-            mispEvent.add_attribute('sha256', ast_eval(str(obj.sha256)), comment=pkg.title or None)
+            attribute = mispEvent.add_attribute('sha256', ast_eval(
+                str(obj.sha256)), comment=pkg.title or None)
 
     # Added support for SHA512 (DB)
     if obj.sha512:
         if len(str(obj.sha512)) == 128:
-            mispEvent.add_attribute('sha512', ast_eval(str(obj.sha512)), comment=pkg.title or None)
+            attribute = mispEvent.add_attribute('sha512', ast_eval(
+                str(obj.sha512)), comment=pkg.title or None)
 
     if importRelated and pkg.object_.related_objects:
         parseRelated(pkg.object_.related_objects, mispEvent, pkg)
 
-    return mispEvent
+    return attribute, mispEvent
 
 
 def buildAddressAttribute(obj, mispEvent, pkg, importRelated=False):
-
+    attribute = None
     # See issue #34
     # Apparently this can be an email?
     if obj.category == "e-mail":
         # it's an email address (for some reason)
         if obj.is_source:
-            mispEvent.add_attribute("email-src", ast_eval(str(obj.address_value)),
-                                    comment=pkg.title or None)
+            attribute = mispEvent.add_attribute("email-src", ast_eval(str(obj.address_value)),
+                                                comment=pkg.title or None)
 
         elif obj.is_destination:
-            mispEvent.add_attribute("email-dst", ast_eval(str(obj.address_value)),
-                                    comment=pkg.title or None)
+            attribute = mispEvent.add_attribute("email-dst", ast_eval(str(obj.address_value)),
+                                                comment=pkg.title or None)
         else:
-            mispEvent.add_attribute("email-src", ast_eval(str(obj.address_value)),
-                                    comment=pkg.title or None)
-           
+            attribute = mispEvent.add_attribute("email-src", ast_eval(str(obj.address_value)),
+                                                comment=pkg.title or None)
+
     elif obj.category == "ipv4-addr":
         if obj.is_source:
-            mispEvent.add_attribute('ip-src', ast_eval(str(obj.address_value)), 
-                                    comment=pkg.title or None)
+            attribute = mispEvent.add_attribute('ip-src', ast_eval(str(obj.address_value)),
+                                                comment=pkg.title or None)
 
         elif obj.is_destination:
-            mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)), 
-                                    comment=pkg.title or None)
-    
+            attribute = mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)),
+                                                comment=pkg.title or None)
+
         else:
             # We don't know, first check if it's an IP range
             if hasattr(obj, "condition") and obj.condition:
                 if obj.condition == "InclusiveBetween":
-                    # Ok, so it's a range. hm. Shall we add them seperately#comma#or together?
-                    mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value[0])))
-                    mispEvent.add_attribute('ip-dst', ast_eval(str(obj.add_attribute[1])))
-            
+                    # Ok, so it's a range. hm. Shall we add them
+                    # seperately#comma#or together?
+                    attribute = mispEvent.add_attribute(
+                        'ip-dst', ast_eval(str(obj.address_value[0])))
+                    attribute = mispEvent.add_attribute(
+                        'ip-dst', ast_eval(str(obj.add_attribute[1])))
+
                 elif obj.condition == "Equals":
-                    mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)), 
-                                            comment=pkg.title or None)
-        
+                    attribute = mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)),
+                                                        comment=pkg.title or None)
+
                 else:
                     # Don't have anything to go on
-                    mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)), 
-                                            comment=pkg.title or None)
+                    attribute = mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)),
+                                                        comment=pkg.title or None)
             else:
                 # Don't have anything to go on
-                mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)),
-                                        comment=pkg.title or None)
+                attribute = mispEvent.add_attribute('ip-dst', ast_eval(str(obj.address_value)),
+                                                    comment=pkg.title or None)
 
     if importRelated and pkg.object_.related_objects:
         parseRelated(pkg.object_.related_objects, mispEvent, pkg)
 
-    return mispEvent
+    return attribute, mispEvent
 
 
 def buildEmailMessageAttribute(obj, mispEvent, pkg, importRelated=False):
+    attribute = None
     if obj.header:
         # We have a header, can check for to/from etc etc
         if obj.header.from_:
-            mispEvent.add_attribute('email-src',
-                                    ast_eval(str(obj.header.from_.address_value)),
-                                    comment=pkg.title or None)
+            attribute = mispEvent.add_attribute('email-src',
+                                                ast_eval(
+                                                    str(obj.header.from_.address_value)),
+                                                comment=pkg.title or None)
         if obj.header.to:
             for mail in obj.header.to:
-                mispEvent.add_attribute('email-dst', ast_eval(mail.address_value), comment=pkg.title or None)
+                attribute = mispEvent.add_attribute(
+                    'email-dst', ast_eval(mail.address_value), comment=pkg.title or None)
         if obj.header.subject:
-            mispEvent.add_attribute('email-subject', ast_eval(str(obj.header.subject)), comment=pkg.title or None)
+            attribute = mispEvent.add_attribute(
+                'email-subject', ast_eval(str(obj.header.subject)), comment=pkg.title or None)
 
     if obj.attachments and pkg.object_.related_objects:
         parseAttachment(pkg.object_.related_objects, mispEvent, pkg)
@@ -202,34 +223,40 @@ def buildEmailMessageAttribute(obj, mispEvent, pkg, importRelated=False):
     elif importRelated and pkg.object_.related_objects:
         parseRelated(pkg.object_.related_objects, mispEvent, pkg)
 
-    return mispEvent
+    return attribute, mispEvent
 
 
 def buildDomainNameAttribute(obj, mispEvent, pkg, importRelated=False):
-    mispEvent.add_attribute('domain', ast_eval(str(obj.value)), comment=pkg.title or None)
+    attribute = None
+    attribute = mispEvent.add_attribute('domain', ast_eval(
+        str(obj.value)), comment=pkg.title or None)
 
     if importRelated and pkg.object_.related_objects:
         parseRelated(pkg.object_.related_objects, mispEvent, pkg)
 
-    return mispEvent
+    return attribute, mispEvent
 
 
 def buildHostnameAttribute(obj, mispEvent, pkg, importRelated=False):
-    mispEvent.add_attribute('hostname', ast_eval(str(obj.hostname_value)), comment=pkg.title or None)
+    attribute = None
+    attribute = mispEvent.add_attribute('hostname', ast_eval(
+        str(obj.hostname_value)), comment=pkg.title or None)
 
     if importRelated and pkg.object_.related_objects:
         parseRelated(pkg.object_.related_objects, mispEvent, pkg)
 
-    return mispEvent
+    return attribute, mispEvent
 
 
 def buildURIAttribute(obj, mispEvent, pkg, importRelated=False):
-    mispEvent.add_attribute('url', ast_eval(str(obj.value)), comment=pkg.title or None)
+    attribute = None
+    attribute = mispEvent.add_attribute('url', ast_eval(
+        str(obj.value)), comment=pkg.title or None)
 
     if importRelated and pkg.object_.related_objects:
         parseRelated(pkg.object_.related_objects, mispEvent, pkg)
 
-    return mispEvent
+    return attribute, mispEvent
 
 
 def identifyHash(hsh):
@@ -246,6 +273,168 @@ def identifyHash(hsh):
             possible_hashes.append(h)
             possible_hashes.append("filename|{}".format(h))
     return possible_hashes
+
+
+def parseThreatConnectTags(event, attribute, description):
+    """
+    Parse threatconnect metrics and add them as tags for MISP attributes
+    https://threatconnect.com/stix-taxii/
+    """
+    try:
+        tags = {"source": "", "threatassess": "",
+                "falsepositives": "", "owner": ""}
+        description = str(description)
+
+        match = re.search(src_pattern, description)
+        if match and len(match.groups()) == 1:
+            tags["source"] = match.group(1)
+
+        match = re.search(threatassess_pattern, description)
+        if match and len(match.groups()) == 1:
+            tags["threatassess"] = match.group(1)
+
+        match = re.search(falsepositives_pattern, description)
+        if match and len(match.groups()) == 1:
+            tags["falsepositives"] = match.group(1)
+
+        match = re.search(owner_pattern, description)
+        if match and len(match.groups()) == 1:
+            tags["owner"] = match.group(1)
+
+        for tag in tags:
+            if tags[tag]:
+                event.add_attribute_tag("Threatconnect:{}={}".format(
+                    str(tag), str(tags[tag]).strip()), attribute.uuid)
+
+    except Exception as ex:
+        log.exception("Exception Parsing Threatconnect tags")
+
+    return attribute, event
+
+
+def parseIndicators(event, pkg):
+    stix_header = pkg.stix_header
+    header = {"information_source.identity.name": "",
+              "information_source.description": "", "information_source.references": ""}
+
+    # Parse select vocabulary from stix_header
+    if hasattr(stix_header,
+               "information_source") and stix_header.information_source:
+        information_source = stix_header.information_source
+        if (hasattr(information_source, "identity") and information_source.identity
+                and hasattr(information_source.identity, "name") and information_source.identity.name):
+            header["information_source.identity.name"] = information_source.identity.name
+            event.add_tag("STIX:Producer={}".format(
+                header["information_source.identity.name"]))
+            log.debug("Information Source:%s",
+                      header["information_source.identity.name"])
+        if hasattr(information_source,
+                   "decription") and information_source.description:
+            header["information_source.description"] = information_source.description
+            log.debug("Information source description:%s",
+                      header["information_source.description"])
+        if hasattr(information_source,
+                   "references") and information_source.references:
+            header["information_source.references"] = ';'.join(
+                list(information_source.references)).strip(';')
+            log.debug("Information source references:%s",
+                      header["information_source.references"])
+    event_info = "Description:{}\nProducer:{}\nReferernces:{}\n".format(
+        header["information_source.description"], header["information_source.identity.name"], header["information_source.references"]
+    )
+
+    has_indicators = False
+    for intent in pkg.stix_header.package_intents:
+        if str(intent).lower() == "indicators":
+            has_indicators = True
+            break
+
+    indicators = None
+    if has_indicators:
+        indicators = pkg.indicators
+    else:
+        log.info("No indicators!")
+        return event
+
+    processed = set()
+    producers = set()
+    for indicator in indicators:
+        meta = {"title": "", "description": "", "producer.identity.name": "",
+                "producer.references": "", "producer.time.produced_time": ""}
+
+        # Loop through each indicator object and parse tags,comment data and
+        # sighting
+        if hasattr(indicator, "observable") and isinstance(
+                indicator.observable, cybox.core.observable.Observable):
+            if indicator.observable.id_ in processed:
+                continue
+
+        if indicator.id_.startswith("threatconnect"):
+            meta["threatconnect"] = True
+        attribute, event_ = buildAttribute(indicator.observable, event)
+        if event_:
+            event = event_
+
+        if not attribute:
+            log.info("Failed to get an attribute object")
+            return event
+        if not hasattr(attribute, "comment"):
+            attribute.comment = ""
+        if hasattr(indicator, "title") and indicator.title:
+            meta["title"] = indicator.title
+            log.debug("Title:%s", meta["title"])
+        if hasattr(indicator, "description") and indicator.description:
+            meta["description"] = indicator.description
+            log.debug("Description:%s", meta["description"])
+
+            # Parse threatconnect metrics:
+            # https://threatconnect.com/stix-taxii/
+            if "threatconnect" in meta and meta["threatconnect"]:
+                parseThreatConnectTags(event, attribute, meta["description"])
+
+        if hasattr(indicator, "confidence") and indicator.confidence and hasattr(
+                indicator.confidence, "value") and indicator.confidence.value:
+            log.debug("Confidence:%s", indicator.confidence.value)
+            event.add_attribute_tag("STIX:Confidence={}".format(
+                str(indicator.confidence.value)), attribute.uuid)
+        if hasattr(indicator, "producer") and indicator.producer:
+            producer = indicator.producer
+            if hasattr(producer, "identity") and producer.identity and hasattr(
+                    producer.identity, "name") and producer.identity.name:
+                meta["producer.identity.name"] = producer.identity.name
+                log.debug("Producer:%s", producer.identity.name)
+                producers.add(producer.identity.name)
+                event.add_attribute_tag("STIX:Producer={}".format(
+                    str(producer.identity.name)), attribute.uuid)
+            if hasattr(producer, "references") and producer.references:
+                meta["producer.references"] = ';'.join(
+                    list(producer.references)).strip(';')
+                log.debug("Producer references:%s", meta["producer.references"])
+            if hasattr(producer, "time") and producer.time and hasattr(
+                    producer.time, "produced_time") and producer.time.produced_time:
+                meta["producer.time.produced_time"] = str(
+                    producer.time.produced_time.to_dict())
+                log.debug("Produced time:%s",
+                          meta["producer.time.produced_time"])
+        if hasattr(indicator, "sightings") and indicator.sightings and hasattr(
+                indicator.sightings, "sightings_count") and indicator.sightings.sightings_count:
+            log.debug("Sightings:%s", indicator.sightings.sightings_count)
+            misp_sighting = {"id": attribute.id, "uuid": attribute.uuid,
+                             "value": indicator.sightings.sightings_count, "type": 0}
+            if meta["producer.identity.name"]:
+                misp_sighting["source"] = meta["producer.identity.name"]
+            event.add_sighting(misp_sighting, attribute=attribute)
+
+        attribute.comment = "{comment}\nTitle:{title}\nTime:{time}\n\nDescription:{description}\nProducer:{producer}\nReferences:{references}\n\nEvent Information:{info}\n".format(
+            comment=attribute.comment, title=meta["title"], time=meta["producer.time.produced_time"],
+            description=meta["description"], producer=meta["producer.identity.name"], references=meta["producer.references"], info=event_info)
+
+        # Add an event tag that includes a list of all the information sources
+        # for the attributes in the feed.
+        if len(producers) > 0:
+            event.add_tag("STIX:Producer={}".format(
+                ','.join(list(producers)).strip(',')))
+    return event
 
 
 def buildEvent(pkg, **kwargs):
@@ -270,33 +459,46 @@ def buildEvent(pkg, **kwargs):
         log.debug("Found description %s", pkg.description)
         event.add_attribute("comment", pkg.description)
 
+    # Attempt to explicitly parse attributes using indicators object metadata
+    event = parseIndicators(event, pkg)
+
     log.debug("Beginning to Lint_roll...")
     ids = []
     to_process = []
-    for obj in lintRoll(pkg):
-        if isinstance(obj, cybox.core.observable.Observable):
-            if obj.id_ not in ids:
-                ids.append(obj.id_)
-                to_process.append(obj)
 
-    log.debug("Processing %s object...", len(to_process))
-    for obj in to_process:
-        log.debug("Working on %s...", obj)
-        # This will find literally every object ever.
-        try:
-            event = buildAttribute(obj, event)
-        except Exception as ex:
-            log.exception(ex)
+    # if we failed to parse any attributes for some reason, attempt the
+    # lint_roll based parsing
+    if not event or len(event.attributes) < 1:
+        log.info("Resorting to Lint Roll:%s",str(pkg.to_json()))
+
+
+        for obj in lintRoll(pkg):
+            if isinstance(obj, cybox.core.observable.Observable):
+                if obj.id_ not in ids:
+                    ids.append(obj.id_)
+                    to_process.append(obj)
+
+        log.debug("Processing %s object...", len(to_process))
+        for obj in to_process:
+            # This will find literally every object ever.
+            try:
+                attribute, event_ = buildAttribute(obj, event)
+                if event_:
+                    event = event_
+            except Exception as ex:
+                log.exception(ex)
     # Now make sure we only have unique items
     log.debug("Making sure we only have Unique attributes...")
-    
+
     uniqueAttribValues = []
 
     for attrindex, attrib in enumerate(event.attributes):
         if attrib.value not in uniqueAttribValues:
             uniqueAttribValues.append(attrib.value)
         else:
-            log.debug("Removed duplicated attribute in package: %s", attrib.value)
+            log.debug(
+                "Removed duplicated attribute in package: %s",
+                attrib.value)
             event.attributes.pop(attrindex)
 
     log.debug("Finished parsing attributes.")
@@ -305,6 +507,7 @@ def buildEvent(pkg, **kwargs):
 
 def buildAttribute(pkg, mispEvent):
     try:
+        attribute = None
         # Check if the object is a cybox observable
         if isinstance(pkg, cybox.core.observable.Observable):
             if hasattr(pkg, "object_") and pkg.object_:
@@ -316,36 +519,45 @@ def buildAttribute(pkg, mispEvent):
                 # Here comes the fun!
                 if type_ == address_object.Address:
                     # Now script uses buildAddressAttribute (DB)
-                    buildAddressAttribute(obj, mispEvent, pkg, True)
+                    attribute, event_ = buildAddressAttribute(
+                        obj, mispEvent, pkg, True)
 
                 elif type_ == domain_name_object.DomainName:
                     # Now script uses buildDomainNameAttribute (DB)
-                    buildDomainNameAttribute(obj, mispEvent, pkg, True)
+                    attribute, event_ = buildDomainNameAttribute(
+                        obj, mispEvent, pkg, True)
 
                 elif type_ == hostname_object.Hostname:
                     # Now script uses buildHostnameAttribute
-                    buildHostnameAttribute(obj, mispEvent, pkg, True)
+                    attribute, event_ = buildHostnameAttribute(
+                        obj, mispEvent, pkg, True)
 
                 elif type_ == socket_address_object.SocketAddress:
                     if obj.ip_address:
-                        buildAddressAttribute(obj.ip_address, mispEvent, pkg, True)
+                        attribute, event_ = buildAddressAttribute(
+                            obj.ip_address, mispEvent, pkg, True)
                     if obj.hostname:
-                        buildHostnameAttribute(obj.hostname, mispEvent, pkg, True)
+                        attribute, event_ = buildHostnameAttribute(
+                            obj.hostname, mispEvent, pkg, True)
 
                 elif type_ == uri_object.URI:
                     # Now script uses buildURIAttribute (DB)
-                    buildURIAttribute(obj, mispEvent, pkg, True)
+                    attribute, event_ = buildURIAttribute(
+                        obj, mispEvent, pkg, True)
 
                 elif type_ == file_object.File:
                     # Now script uses buildFileAttribute (DB)
-                    buildFileAttribute(obj, mispEvent, pkg, True)
+                    attribute, event_ = buildFileAttribute(
+                        obj, mispEvent, pkg, True)
 
                 elif type_ == email_message_object.EmailMessage:
                     # Now script uses buildEmailMessageAttribute (DB)
-                    buildEmailMessageAttribute(obj, mispEvent, pkg, True)
+                    attribute, event_ = buildEmailMessageAttribute(
+                        obj, mispEvent, pkg, True)
 
                 elif type_ == mutex_object.Mutex:
-                    mispEvent.add_attribute('mutex', ast_eval(str(obj.name)), comment=pkg.title or None)
+                    attribute = mispEvent.add_attribute(
+                        'mutex', ast_eval(str(obj.name)), comment=pkg.title or None)
                 elif type_ == whois_object.WhoisEntry:
                     pass
                 elif type_ == win_registry_key_object.WinRegistryKey:
@@ -355,10 +567,11 @@ def buildAttribute(pkg, mispEvent):
                 elif type_ == http_session_object.HTTPSession:
                     pass
                 elif type_ == pipe_object.Pipe:
-                    mispEvent.add_attribute('named pipe', ast_eval(str(obj.name)), comment=pkg.title or None)
+                    attribute = mispEvent.add_attribute(
+                        'named pipe', ast_eval(str(obj.name)), comment=pkg.title or None)
                 elif type_ == as_object.AS:
-                    mispEvent.add_attribute('AS', ast_eval(str(obj.number)),
-                                            comment=pkg.title or ast_eval(str(obj.name)) or None)
+                    attribute, event_ = mispEvent.add_attribute('AS', ast_eval(str(obj.number)),
+                                                                comment=pkg.title or ast_eval(str(obj.name)) or None)
                 elif type_ == win_executable_file_object.WinExecutableFile:
                     pass
                 elif type_ == win_process_object.WinProcess:
@@ -375,4 +588,4 @@ def buildAttribute(pkg, mispEvent):
         log.error(ex)
         log.exception(ex, exc_info=True)
 
-    return mispEvent
+    return attribute, mispEvent


### PR DESCRIPTION
## Changelog

- Added a parseIndicators function to attempt to parse details of the indicators objects such as confidence,information source and sightings and add them as properties of the attributes. if this approach fails, revert to the previous 'lint roll' approach to grab all observables and just get only the value. 
- Update attribute and event tags as well as attribute comment with indicator metadata for the observable/attribute
- Parse threatconnect metrics/tags: https://threatconnect.com/stix-taxii/git 
- buildAttribute and attribute parsing functions return the attribute along with the event
- autopep8!
- Tested and working great with alienvault and threatconnect feeds

